### PR TITLE
CP-21656: Dynamically Populate Service Endpoints

### DIFF
--- a/pkg/cmd/config/command_test.go
+++ b/pkg/cmd/config/command_test.go
@@ -1,43 +1,80 @@
 package config_test
 
 import (
-	"os"
-	"testing"
+    "context"
+    "os"
+    "testing"
 
-	"github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/assert"
+    corev1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/cmd/config"
+    "github.com/cloudzero/cloudzero-agent-validator/pkg/cmd/config"
+    "github.com/cloudzero/cloudzero-agent-validator/pkg/k8s"
 )
 
 func TestGenerate(t *testing.T) {
-	values := map[string]interface{}{
-		"ChartVerson":         "1.0.0",
-		"AgentVersion":        "1.0.0",
-		"AccountID":           "123456789",
-		"ClusterName":         "test-cluster",
-		"Region":              "us-west-2",
-		"CloudzeroHost":       "https://cloudzero.com",
-		"KubeStateMetricsURL": "http://kube-state-metrics.your-namespace.svc.cluster.local:8080",
-		"PromNodeExporterURL": "http://node-exporter.your-namespace.svc.cluster.local:9100",
-	}
+    // Create a fake clientset with some services
+    clientset := fake.NewSimpleClientset(
+        &corev1.Service{
+            ObjectMeta: metav1.ObjectMeta{
+                Name:      "kube-state-metrics",
+                Namespace: "default",
+            },
+            Spec: corev1.ServiceSpec{
+                Ports: []corev1.ServicePort{
+                    {Port: 8080},
+                },
+            },
+        },
+        &corev1.Service{
+            ObjectMeta: metav1.ObjectMeta{
+                Name:      "node-exporter",
+                Namespace: "default",
+            },
+            Spec: corev1.ServiceSpec{
+                Ports: []corev1.ServicePort{
+                    {Port: 9100},
+                },
+            },
+        },
+    )
 
-	outputFile := "test_output.yml"
+    ctx, _ := context.WithCancel(context.Background())
 
-	err := config.Generate(values, outputFile)
-	assert.NoError(t, err)
+    // Fetch service URLs
+    kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(ctx, clientset)
+    assert.NoError(t, err)
 
-	// Verify that the output file exists
-	_, err = os.Stat(outputFile)
-	assert.NoError(t, err)
+    values := map[string]interface{}{
+        "ChartVerson":         "1.0.0",
+        "AgentVersion":        "1.0.0",
+        "AccountID":           "123456789",
+        "ClusterName":         "test-cluster",
+        "Region":              "us-west-2",
+        "CloudzeroHost":       "https://cloudzero.com",
+        "KubeStateMetricsURL": kubeStateMetricsURL,
+        "PromNodeExporterURL": nodeExporterURL,
+    }
 
-	// Read the contents of the output file
-	content, err := os.ReadFile(outputFile)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, content)
+    outputFile := "test_output.yml"
 
-	// TODO: Add assertions to validate the content of the output file
+    err = config.Generate(values, outputFile)
+    assert.NoError(t, err)
 
-	// Clean up the output file
-	err = os.Remove(outputFile)
-	assert.NoError(t, err)
+    // Verify that the output file exists
+    _, err = os.Stat(outputFile)
+    assert.NoError(t, err)
+
+    // Read the contents of the output file
+    content, err := os.ReadFile(outputFile)
+    assert.NoError(t, err)
+    assert.NotEmpty(t, content)
+
+    // TODO: Add assertions to validate the content of the output file
+
+    // Clean up the output file
+    err = os.Remove(outputFile)
+    assert.NoError(t, err)
 }

--- a/pkg/k8s/services_test.go
+++ b/pkg/k8s/services_test.go
@@ -1,38 +1,110 @@
 package k8s_test
 
 import (
-	"context"
-	"testing"
+    "context"
+    "testing"
 
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+    corev1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/k8s"
+    "github.com/cloudzero/cloudzero-agent-validator/pkg/k8s"
 )
 
-// TestListServices tests the ListServices function
-func TestListServices(t *testing.T) {
-	// Create a fake clientset with some services
-	clientset := fake.NewSimpleClientset(
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "service1",
-				Namespace: "default",
-			},
-		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "service2",
-				Namespace: "kube-system",
-			},
-		},
-	)
+// TestGetServiceURLs tests the GetServiceURLs function
+func TestGetServiceURLs(t *testing.T) {
+    tests := []struct {
+        name                    string
+        services                []corev1.Service
+        expectedKubeStateURL    string
+        expectedNodeExporterURL string
+        expectError             bool
+    }{
+        {
+            name: "Both services found",
+            services: []corev1.Service{
+                {
+                    ObjectMeta: metav1.ObjectMeta{
+                        Name:      "kube-state-metrics",
+                        Namespace: "default",
+                    },
+                    Spec: corev1.ServiceSpec{
+                        Ports: []corev1.ServicePort{
+                            {Port: 8080},
+                        },
+                    },
+                },
+                {
+                    ObjectMeta: metav1.ObjectMeta{
+                        Name:      "node-exporter",
+                        Namespace: "default",
+                    },
+                    Spec: corev1.ServiceSpec{
+                        Ports: []corev1.ServicePort{
+                            {Port: 9100},
+                        },
+                    },
+                },
+            },
+            expectedKubeStateURL:    "http://kube-state-metrics.default.svc.cluster.local:8080",
+            expectedNodeExporterURL: "http://node-exporter.default.svc.cluster.local:9100",
+            expectError:             false,
+        },
+        {
+            name: "Kube-state-metrics service not found",
+            services: []corev1.Service{
+                {
+                    ObjectMeta: metav1.ObjectMeta{
+                        Name:      "node-exporter",
+                        Namespace: "default",
+                    },
+                    Spec: corev1.ServiceSpec{
+                        Ports: []corev1.ServicePort{
+                            {Port: 9100},
+                        },
+                    },
+                },
+            },
+            expectedKubeStateURL:    "",
+            expectedNodeExporterURL: "",
+            expectError:             true,
+        },
+        {
+            name: "Node-exporter service not found",
+            services: []corev1.Service{
+                {
+                    ObjectMeta: metav1.ObjectMeta{
+                        Name:      "kube-state-metrics",
+                        Namespace: "default",
+                    },
+                    Spec: corev1.ServiceSpec{
+                        Ports: []corev1.ServicePort{
+                            {Port: 8080},
+                        },
+                    },
+                },
+            },
+            expectedKubeStateURL:    "",
+            expectedNodeExporterURL: "",
+            expectError:             true,
+        },
+    }
 
-	ctx, _ := context.WithCancel(context.Background())
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            clientset := fake.NewSimpleClientset(&corev1.ServiceList{Items: tt.services})
 
-	// Test listing services
-	err := k8s.ListServices(ctx, clientset)
-	assert.NoError(t, err)
+            kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(context.Background(), clientset)
+            if (err != nil) != tt.expectError {
+                t.Errorf("GetServiceURLs() error = %v, expectError %v", err, tt.expectError)
+                return
+            }
+            if kubeStateMetricsURL != tt.expectedKubeStateURL {
+                t.Errorf("GetServiceURLs() kubeStateMetricsURL = %v, expected %v", kubeStateMetricsURL, tt.expectedKubeStateURL)
+            }
+            if nodeExporterURL != tt.expectedNodeExporterURL {
+                t.Errorf("GetServiceURLs() nodeExporterURL = %v, expected %v", nodeExporterURL, tt.expectedNodeExporterURL)
+            }
+        })
+    }
 }


### PR DESCRIPTION
This PR modifies the `generate` command so that it populates the `kube_state_metrics_service_endpoint` and `prometheus_node_exporter_service_endpoint` using the work done in #27, to find all services within a cluster.

``` bash
(system) ➜  cloudzero-agent-validator git:(cp-21656) ✗ ./bin/cloudzero-agent-validator config generate --kubeconfig /tmp/bdren.kubeconfig --account 123 --cluster test --region us-east-1 --kubeconfig /tmp/bdren.kubeconfig                                                      <region:us-east-1>(⎈|arn:aws:eks:us-east-1:975482786146:cluster/bdren:default)
versions:
  chart_version: 0.0.26
  agent_version: latest

logging:
  level: info
  location: ./cloudzero-agent-validator.log

deployment:
  account_id:  123
  cluster_name:  test
  region:  us-east-1

cloudzero:
  host:  https://api.cloudzero.com
  credentials_file: /etc/config/prometheus/secrets/value

prometheus:
  kube_state_metrics_service_endpoint:  http://cz-prom-agent-kube-state-metrics.default.svc.cluster.local:8080
  prometheus_node_exporter_service_endpoint:  http://cz-prom-agent-prometheus-node-exporter.default.svc.cluster.local:9100
  configurations:
    - /etc/config/prometheus/configmaps/prometheus.yml

diagnostics:
  stages:
    - name: pre-start
      enforce: true
      checks:
        - egress_reachable
        - api_key_valid
    - name: post-start
      enforce: false
      checks:
        - k8s_version
        - kube_state_metrics_reachable
        - node_exporter_reachable
        - scrape_cfg
    - name: pre-stop
      enforce: false
      checks:

```