### PR TITLE
CP-21861: Modify Generate Command to Update Pod ConfigMap with Service Endpoints

### DIFF
--- a/pkg/cmd/config/command.go
+++ b/pkg/cmd/config/command.go
@@ -24,7 +24,10 @@ var (
 )
 
 type ScrapeConfigData struct {
-	Targets []string
+	Targets        []string
+	ClusterName    string
+	CloudAccountID string
+	Region         string
 }
 
 func NewCommand(ctx context.Context) *cli.Command {
@@ -60,7 +63,12 @@ func NewCommand(ctx context.Context) *cli.Command {
 					}
 
 					targets := []string{kubeStateMetricsURL, nodeExporterURL}
-					scrapeConfigData := ScrapeConfigData{Targets: targets}
+					scrapeConfigData := ScrapeConfigData{
+						Targets:        targets,
+						ClusterName:    c.String(config.FlagClusterName),
+						CloudAccountID: c.String(config.FlagAccountID),
+						Region:         c.String(config.FlagRegion),
+					}
 
 					configContent, err := Generate(scrapeConfigData)
 					if err != nil {

--- a/pkg/cmd/config/command_test.go
+++ b/pkg/cmd/config/command_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	// Create a fake clientset with some services
+	// Create a fake clientset with some services and a ConfigMap
 	clientset := fake.NewSimpleClientset(
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -39,6 +39,16 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-configmap",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
 	)
 
 	ctx, _ := context.WithCancel(context.Background())
@@ -46,6 +56,13 @@ func TestGenerate(t *testing.T) {
 	// Fetch service URLs
 	kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(ctx, clientset)
 	assert.NoError(t, err)
+
+	// Fetch ConfigMap
+	configMap, err := k8s.GetConfigMap(ctx, clientset, "default", "test-configmap")
+	assert.NoError(t, err)
+
+	// Print ConfigMap
+	config.PrintConfigMap(configMap)
 
 	values := map[string]interface{}{
 		"ChartVerson":         "1.0.0",

--- a/pkg/cmd/config/command_test.go
+++ b/pkg/cmd/config/command_test.go
@@ -49,13 +49,23 @@ func TestGenerate(t *testing.T) {
 
 	// Define the scrape config data
 	scrapeConfigData := config.ScrapeConfigData{
-		Targets: []string{kubeStateMetricsURL, nodeExporterURL},
+		Targets:        []string{kubeStateMetricsURL, nodeExporterURL},
+		ClusterName:    "test-cluster",
+		CloudAccountID: "123456789",
+		Region:         "us-west-2",
 	}
 
 	// Generate the configuration content
 	configContent, err := config.Generate(scrapeConfigData)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, configContent)
+
+	// Validate the dynamically populated values
+	assert.Contains(t, configContent, kubeStateMetricsURL)
+	assert.Contains(t, configContent, nodeExporterURL)
+	assert.Contains(t, configContent, "cluster_name=test-cluster")
+	assert.Contains(t, configContent, "cloud_account_id=123456789")
+	assert.Contains(t, configContent, "region=us-west-2")
 
 	// Define the ConfigMap data
 	configMapData := map[string]string{

--- a/pkg/cmd/config/internal/scrape_config.tmpl
+++ b/pkg/cmd/config/internal/scrape_config.tmpl
@@ -1,0 +1,45 @@
+- job_name: custom-kube-state-metrics
+  honor_timestamps: true
+  track_timestamps_staleness: false
+  scrape_interval: 120s
+  scrape_timeout: 10s
+  scrape_protocols:
+  - OpenMetricsText1.0.0
+  - OpenMetricsText0.0.1
+  - PrometheusText0.0.4
+  metrics_path: /metrics
+  enable_compression: true
+  static_configs:
+    - targets:
+{{- range .Targets }}
+      - {{ . }}
+{{- end }}
+  relabel_configs:
+    - separator: ;
+      regex: __meta_kubernetes_service_label_(.+)
+      replacement: $1
+      action: labelmap
+    - source_labels: [__meta_kubernetes_namespace]
+      separator: ;
+      regex: (.*)
+      target_label: namespace
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_service_name]
+      separator: ;
+      regex: (.*)
+      target_label: service
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_pod_node_name]
+      separator: ;
+      regex: (.*)
+      target_label: node
+      replacement: $1
+      action: replace
+  metric_relabel_configs:
+    - source_labels: [__name__]
+      regex: "^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info)$"
+      action: keep
+    - action: labelkeep
+      regex: "^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$"

--- a/pkg/cmd/config/internal/scrape_config.tmpl
+++ b/pkg/cmd/config/internal/scrape_config.tmpl
@@ -1,45 +1,144 @@
-- job_name: custom-kube-state-metrics
+global:
+  scrape_interval: 1m
+  scrape_timeout: 10s
+  scrape_protocols:
+  - OpenMetricsText1.0.0
+  - OpenMetricsText0.0.1
+  - PrometheusText0.0.4
+  evaluation_interval: 1m
+scrape_configs:
+- job_name: cloudzero-nodes-cadvisor
   honor_timestamps: true
   track_timestamps_staleness: false
-  scrape_interval: 120s
+  scrape_interval: 1m
   scrape_timeout: 10s
   scrape_protocols:
   - OpenMetricsText1.0.0
   - OpenMetricsText0.0.1
   - PrometheusText0.0.4
   metrics_path: /metrics
+  scheme: https
   enable_compression: true
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  follow_redirects: true
+  enable_http2: true
+  relabel_configs:
+  - separator: ;
+    regex: __meta_kubernetes_node_label_(.+)
+    replacement: $1
+    action: labelmap
+  - separator: ;
+    regex: (.*)
+    target_label: __address__
+    replacement: kubernetes.default.svc:443
+    action: replace
+  - source_labels: [__meta_kubernetes_node_name]
+    separator: ;
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+    action: replace
+  - source_labels: [__meta_kubernetes_node_name]
+    separator: ;
+    regex: (.*)
+    target_label: node
+    replacement: $1
+    action: replace
+  metric_relabel_configs:
+  - separator: ;
+    regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+    replacement: $1
+    action: labelkeep
+  - source_labels: [__name__]
+    separator: ;
+    regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+    replacement: $1
+    action: keep
+  kubernetes_sd_configs:
+  - role: node
+    kubeconfig_file: ""
+    follow_redirects: true
+    enable_http2: true
+- job_name: static-kube-state-metrics
+  honor_timestamps: true
+  track_timestamps_staleness: false
+  scrape_interval: 1m
+  scrape_timeout: 10s
+  scrape_protocols:
+  - OpenMetricsText1.0.0
+  - OpenMetricsText0.0.1
+  - PrometheusText0.0.4
+  metrics_path: /metrics
+  scheme: http
+  enable_compression: true
+  follow_redirects: true
+  enable_http2: true
+  relabel_configs:
+  - separator: ;
+    regex: __meta_kubernetes_service_label_(.+)
+    replacement: $1
+    action: labelmap
+  - source_labels: [__meta_kubernetes_namespace]
+    separator: ;
+    regex: (.*)
+    target_label: namespace
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    separator: ;
+    regex: (.*)
+    target_label: service
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    separator: ;
+    regex: (.*)
+    target_label: node
+    replacement: $1
+    action: replace
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    separator: ;
+    regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info)$
+    replacement: $1
+    action: keep
+  - separator: ;
+    regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+    replacement: $1
+    action: labelkeep
   static_configs:
-    - targets:
+  - targets:
 {{- range .Targets }}
       - {{ . }}
 {{- end }}
-  relabel_configs:
-    - separator: ;
-      regex: __meta_kubernetes_service_label_(.+)
-      replacement: $1
-      action: labelmap
-    - source_labels: [__meta_kubernetes_namespace]
-      separator: ;
-      regex: (.*)
-      target_label: namespace
-      replacement: $1
-      action: replace
-    - source_labels: [__meta_kubernetes_service_name]
-      separator: ;
-      regex: (.*)
-      target_label: service
-      replacement: $1
-      action: replace
-    - source_labels: [__meta_kubernetes_pod_node_name]
-      separator: ;
-      regex: (.*)
-      target_label: node
-      replacement: $1
-      action: replace
-  metric_relabel_configs:
-    - source_labels: [__name__]
-      regex: "^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info)$"
-      action: keep
-    - action: labelkeep
-      regex: "^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$"
+remote_write:
+- url: https://api.cloudzero.com/v1/container-metrics?cluster_name={{ .ClusterName }}&cloud_account_id={{ .CloudAccountID }}&region={{ .Region }}
+  remote_timeout: 30s
+  write_relabel_configs:
+  - source_labels: [__name__]
+    separator: ;
+    regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+    replacement: $1
+    action: keep
+  authorization:
+    type: Bearer
+    credentials_file: /etc/config/prometheus/secrets/value
+  follow_redirects: true
+  enable_http2: true
+  queue_config:
+    capacity: 10000
+    max_shards: 50
+    min_shards: 1
+    max_samples_per_send: 2000
+    batch_send_deadline: 5s
+    min_backoff: 30ms
+    max_backoff: 5s
+  metadata_config:
+    send: false
+    send_interval: 1m
+    max_samples_per_send: 2000

--- a/pkg/k8s/services.go
+++ b/pkg/k8s/services.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -58,4 +59,13 @@ func GetServiceURLs(ctx context.Context, clientset kubernetes.Interface) (string
 	}
 
 	return kubeStateMetricsURL, nodeExporterURL, nil
+}
+
+// GetConfigMap retrieves the ConfigMap from the specified namespace
+func GetConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.ConfigMap, error) {
+	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting configmap")
+	}
+	return configMap, nil
 }

--- a/pkg/k8s/services.go
+++ b/pkg/k8s/services.go
@@ -69,3 +69,12 @@ func GetConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace
 	}
 	return configMap, nil
 }
+
+// UpdateConfigMap updates the ConfigMap in the specified namespace
+func UpdateConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace string, configMap *corev1.ConfigMap) error {
+	_, err := clientset.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrap(err, "updating configmap")
+	}
+	return nil
+}

--- a/pkg/k8s/services.go
+++ b/pkg/k8s/services.go
@@ -7,74 +7,73 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// BuildKubeClient builds a Kubernetes clientset from a kubeconfig path
+// UpdateConfigMap updates the specified ConfigMap
+func UpdateConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace, name string, data map[string]string) error {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+
+	_, err := clientset.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+	if err == nil {
+		return nil
+	}
+
+	// If the ConfigMap does not exist, create it
+	if k8serrors.IsNotFound(err) {
+		_, createErr := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		if createErr != nil {
+			return errors.Wrap(createErr, "creating configmap")
+		}
+		return nil
+	}
+
+	return errors.Wrap(err, "updating configmap")
+}
+
+// BuildKubeClient builds a Kubernetes clientset from the kubeconfig file
 func BuildKubeClient(kubeconfigPath string) (kubernetes.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "building kubeconfig")
 	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating clientset")
+		return nil, errors.Wrap(err, "building clientset")
 	}
-
 	return clientset, nil
 }
 
-// GetServiceURLs retrieves the URLs for services containing 'kube-state-metrics' and 'node-exporter' substrings
+// GetServiceURLs fetches the URLs for services containing the substrings "kube-state-metrics" and "node-exporter"
 func GetServiceURLs(ctx context.Context, clientset kubernetes.Interface) (string, string, error) {
-	// List all services in all namespaces
-	services, err := clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	services, err := clientset.CoreV1().Services("default").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", "", errors.Wrap(err, "listing services")
 	}
 
 	var kubeStateMetricsURL, nodeExporterURL string
 
-	// Filter services for substrings 'kube-state-metrics' and 'node-exporter' and generate URLs
 	for _, service := range services.Items {
 		if strings.Contains(service.Name, "kube-state-metrics") {
-			if len(service.Spec.Ports) > 0 {
-				kubeStateMetricsURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, service.Spec.Ports[0].Port)
-			}
-		} else if strings.Contains(service.Name, "node-exporter") {
-			if len(service.Spec.Ports) > 0 {
-				nodeExporterURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, service.Spec.Ports[0].Port)
-			}
+			kubeStateMetricsURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, service.Spec.Ports[0].Port)
+		}
+		if strings.Contains(service.Name, "node-exporter") {
+			nodeExporterURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, service.Spec.Ports[0].Port)
 		}
 	}
 
-	if kubeStateMetricsURL == "" {
-		return "", "", fmt.Errorf("kube-state-metrics service not found. Please install kube-state-metrics")
-	}
-
-	if nodeExporterURL == "" {
-		return "", "", fmt.Errorf("node-exporter service not found. Please install node-exporter")
+	if kubeStateMetricsURL == "" || nodeExporterURL == "" {
+		return "", "", errors.New("required services not found")
 	}
 
 	return kubeStateMetricsURL, nodeExporterURL, nil
-}
-
-// GetConfigMap retrieves the ConfigMap from the specified namespace
-func GetConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.ConfigMap, error) {
-	configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrap(err, "getting configmap")
-	}
-	return configMap, nil
-}
-
-// UpdateConfigMap updates the ConfigMap in the specified namespace
-func UpdateConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace string, configMap *corev1.ConfigMap) error {
-	_, err := clientset.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
-	if err != nil {
-		return errors.Wrap(err, "updating configmap")
-	}
-	return nil
 }

--- a/pkg/k8s/services_test.go
+++ b/pkg/k8s/services_test.go
@@ -108,3 +108,55 @@ func TestGetServiceURLs(t *testing.T) {
 		})
 	}
 }
+
+// TestGetConfigMap tests the GetConfigMap function
+func TestGetConfigMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMaps    []corev1.ConfigMap
+		namespace     string
+		configMapName string
+		expectError   bool
+	}{
+		{
+			name: "ConfigMap found",
+			configMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-configmap",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			namespace:     "default",
+			configMapName: "test-configmap",
+			expectError:   false,
+		},
+		{
+			name:          "ConfigMap not found",
+			configMaps:    []corev1.ConfigMap{},
+			namespace:     "default",
+			configMapName: "nonexistent-configmap",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(&corev1.ConfigMapList{Items: tt.configMaps})
+
+			configMap, err := k8s.GetConfigMap(context.Background(), clientset, tt.namespace, tt.configMapName)
+			if (err != nil) != tt.expectError {
+				t.Errorf("GetConfigMap() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if !tt.expectError && configMap.Name != tt.configMapName {
+				t.Errorf("GetConfigMap() configMap.Name = %v, expected %v", configMap.Name, tt.configMapName)
+			}
+		})
+	}
+}

--- a/pkg/k8s/services_test.go
+++ b/pkg/k8s/services_test.go
@@ -109,58 +109,6 @@ func TestGetServiceURLs(t *testing.T) {
 	}
 }
 
-// TestGetConfigMap tests the GetConfigMap function
-func TestGetConfigMap(t *testing.T) {
-	tests := []struct {
-		name          string
-		configMaps    []corev1.ConfigMap
-		namespace     string
-		configMapName string
-		expectError   bool
-	}{
-		{
-			name: "ConfigMap found",
-			configMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-configmap",
-						Namespace: "default",
-					},
-					Data: map[string]string{
-						"key1": "value1",
-						"key2": "value2",
-					},
-				},
-			},
-			namespace:     "default",
-			configMapName: "test-configmap",
-			expectError:   false,
-		},
-		{
-			name:          "ConfigMap not found",
-			configMaps:    []corev1.ConfigMap{},
-			namespace:     "default",
-			configMapName: "nonexistent-configmap",
-			expectError:   true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset(&corev1.ConfigMapList{Items: tt.configMaps})
-
-			configMap, err := k8s.GetConfigMap(context.Background(), clientset, tt.namespace, tt.configMapName)
-			if (err != nil) != tt.expectError {
-				t.Errorf("GetConfigMap() error = %v, expectError %v", err, tt.expectError)
-				return
-			}
-			if !tt.expectError && configMap.Name != tt.configMapName {
-				t.Errorf("GetConfigMap() configMap.Name = %v, expected %v", configMap.Name, tt.configMapName)
-			}
-		})
-	}
-}
-
 // TestUpdateConfigMap tests the UpdateConfigMap function
 func TestUpdateConfigMap(t *testing.T) {
 	tests := []struct {
@@ -186,23 +134,32 @@ func TestUpdateConfigMap(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name:             "Create ConfigMap successfully",
+			initialConfigMap: nil,
+			updatedData: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset(tt.initialConfigMap)
+			clientset := fake.NewSimpleClientset()
+			if tt.initialConfigMap != nil {
+				clientset = fake.NewSimpleClientset(tt.initialConfigMap)
+			}
 
-			// Update the ConfigMap data
-			tt.initialConfigMap.Data = tt.updatedData
-
-			err := k8s.UpdateConfigMap(context.Background(), clientset, tt.initialConfigMap.Namespace, tt.initialConfigMap)
+			err := k8s.UpdateConfigMap(context.Background(), clientset, "default", "test-configmap", tt.updatedData)
 			if (err != nil) != tt.expectError {
 				t.Errorf("UpdateConfigMap() error = %v, expectError %v", err, tt.expectError)
 				return
 			}
 
-			// Verify the ConfigMap was updated
-			updatedConfigMap, err := k8s.GetConfigMap(context.Background(), clientset, tt.initialConfigMap.Namespace, tt.initialConfigMap.Name)
+			// Verify the ConfigMap was updated or created
+			updatedConfigMap, err := clientset.CoreV1().ConfigMaps("default").Get(context.Background(), "test-configmap", metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("GetConfigMap() error = %v", err)
 				return


### PR DESCRIPTION
This PR modifies the `generate` command to update the Service Endpoints for both Node Exporter and KSM.




**Testing**

The updated command and it's output:

``` bash
cloudzero-agent-validator git:(cp-21861) ./bin/cloudzero-agent-validator config generate --kubeconfig /tmp/bdren.kubeconfig --account 123 --cluster test --region us-east-1 --namespace default --configmap cz-prom-agent-configuration --pod cz-prom-agent-cloudzero-agent-server-5b54bdfbbc-b9xgk
```

``` yaml
Name:         cz-prom-agent-configuration
Namespace:    default
Labels:       <none>
Annotations:  <none>

Data
====
prometheus.yml:
----
global:
  scrape_interval: 1m
  scrape_timeout: 10s
  scrape_protocols:
  - OpenMetricsText1.0.0
  - OpenMetricsText0.0.1
  - PrometheusText0.0.4
  evaluation_interval: 1m
scrape_configs:
- job_name: cloudzero-nodes-cadvisor
  honor_timestamps: true
  track_timestamps_staleness: false
  scrape_interval: 1m
  scrape_timeout: 10s
  scrape_protocols:
  - OpenMetricsText1.0.0
  - OpenMetricsText0.0.1
  - PrometheusText0.0.4
  metrics_path: /metrics
  scheme: https
  enable_compression: true
  authorization:
    type: Bearer
    credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  tls_config:
    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    insecure_skip_verify: true
  follow_redirects: true
  enable_http2: true
  relabel_configs:
  - separator: ;
    regex: __meta_kubernetes_node_label_(.+)
    replacement: $1
    action: labelmap
  - separator: ;
    regex: (.*)
    target_label: __address__
    replacement: kubernetes.default.svc:443
    action: replace
  - source_labels: [__meta_kubernetes_node_name]
    separator: ;
    regex: (.+)
    target_label: __metrics_path__
    replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
    action: replace
  - source_labels: [__meta_kubernetes_node_name]
    separator: ;
    regex: (.*)
    target_label: node
    replacement: $1
    action: replace
  metric_relabel_configs:
  - separator: ;
    regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
    replacement: $1
    action: labelkeep
  - source_labels: [__name__]
    separator: ;
    regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
    replacement: $1
    action: keep
  kubernetes_sd_configs:
  - role: node
    kubeconfig_file: ""
    follow_redirects: true
    enable_http2: true
- job_name: static-kube-state-metrics
  honor_timestamps: true
  track_timestamps_staleness: false
  scrape_interval: 1m
  scrape_timeout: 10s
  scrape_protocols:
  - OpenMetricsText1.0.0
  - OpenMetricsText0.0.1
  - PrometheusText0.0.4
  metrics_path: /metrics
  scheme: http
  enable_compression: true
  follow_redirects: true
  enable_http2: true
  relabel_configs:
  - separator: ;
    regex: __meta_kubernetes_service_label_(.+)
    replacement: $1
    action: labelmap
  - source_labels: [__meta_kubernetes_namespace]
    separator: ;
    regex: (.*)
    target_label: namespace
    replacement: $1
    action: replace
  - source_labels: [__meta_kubernetes_service_name]
    separator: ;
    regex: (.*)
    target_label: service
    replacement: $1
    action: replace
  - source_labels: [__meta_kubernetes_pod_node_name]
    separator: ;
    regex: (.*)
    target_label: node
    replacement: $1
    action: replace
  metric_relabel_configs:
  - source_labels: [__name__]
    separator: ;
    regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info)$
    replacement: $1
    action: keep
  - separator: ;
    regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
    replacement: $1
    action: labelkeep
  static_configs:
  - targets:
      - http://cz-prom-agent-kube-state-metrics.default.svc.cluster.local:8080
      - http://cz-prom-agent-prometheus-node-exporter.default.svc.cluster.local:9100
remote_write:
- url: https://api.cloudzero.com/v1/container-metrics?cluster_name=test&cloud_account_id=123&region=us-east-1
  remote_timeout: 30s
  write_relabel_configs:
  - source_labels: [__name__]
    separator: ;
    regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info|node_dmi_info|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
    replacement: $1
    action: keep
  authorization:
    type: Bearer
    credentials_file: /etc/config/prometheus/secrets/value
  follow_redirects: true
  enable_http2: true
  queue_config:
    capacity: 10000
    max_shards: 50
    min_shards: 1
    max_samples_per_send: 2000
    batch_send_deadline: 5s
    min_backoff: 30ms
    max_backoff: 5s
  metadata_config:
    send: false
    send_interval: 1m
    max_samples_per_send: 2000


BinaryData
====

Events:  <none>


```

The output should look the same as before, but behind the scenes the ConfigMap is being updated. For real-world results, see https://github.com/Cloudzero/cloudzero-charts/pull/78.