### PR TITLE
[CP-21861 (part-2)]: Use Namespace Arguement

### DIFF
--- a/pkg/cmd/config/command.go
+++ b/pkg/cmd/config/command.go
@@ -57,7 +57,7 @@ func NewCommand(ctx context.Context) *cli.Command {
 						return err
 					}
 
-					kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(ctx, clientset)
+					kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(ctx, clientset, namespace)
 					if err != nil {
 						return err
 					}

--- a/pkg/k8s/services.go
+++ b/pkg/k8s/services.go
@@ -54,8 +54,8 @@ func BuildKubeClient(kubeconfigPath string) (kubernetes.Interface, error) {
 }
 
 // GetServiceURLs fetches the URLs for services containing the substrings "kube-state-metrics" and "node-exporter"
-func GetServiceURLs(ctx context.Context, clientset kubernetes.Interface) (string, string, error) {
-	services, err := clientset.CoreV1().Services("default").List(ctx, metav1.ListOptions{})
+func GetServiceURLs(ctx context.Context, clientset kubernetes.Interface, namespace string) (string, string, error) {
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", "", errors.Wrap(err, "listing services")
 	}

--- a/pkg/k8s/services_test.go
+++ b/pkg/k8s/services_test.go
@@ -2,8 +2,10 @@ package k8s_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -11,165 +13,112 @@ import (
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/k8s"
 )
 
-// TestGetServiceURLs tests the GetServiceURLs function
 func TestGetServiceURLs(t *testing.T) {
-	tests := []struct {
-		name                    string
-		services                []corev1.Service
-		expectedKubeStateURL    string
-		expectedNodeExporterURL string
-		expectError             bool
-	}{
-		{
-			name: "Both services found",
-			services: []corev1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kube-state-metrics",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{Port: 8080},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "node-exporter",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{Port: 9100},
-						},
-					},
-				},
-			},
-			expectedKubeStateURL:    "http://kube-state-metrics.default.svc.cluster.local:8080",
-			expectedNodeExporterURL: "http://node-exporter.default.svc.cluster.local:9100",
-			expectError:             false,
-		},
-		{
-			name: "Kube-state-metrics service not found",
-			services: []corev1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "node-exporter",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{Port: 9100},
-						},
-					},
-				},
-			},
-			expectedKubeStateURL:    "",
-			expectedNodeExporterURL: "",
-			expectError:             true,
-		},
-		{
-			name: "Node-exporter service not found",
-			services: []corev1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "kube-state-metrics",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{Port: 8080},
-						},
-					},
-				},
-			},
-			expectedKubeStateURL:    "",
-			expectedNodeExporterURL: "",
-			expectError:             true,
-		},
-	}
+	clientset := fake.NewSimpleClientset()
+	ctx := context.TODO()
+	namespace := "test-namespace"
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset(&corev1.ServiceList{Items: tt.services})
+	// Create fake services in the test namespace
+	_, err := clientset.CoreV1().Services(namespace).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-state-metrics",
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port: 8080,
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
 
-			kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(context.Background(), clientset)
-			if (err != nil) != tt.expectError {
-				t.Errorf("GetServiceURLs() error = %v, expectError %v", err, tt.expectError)
-				return
-			}
-			if kubeStateMetricsURL != tt.expectedKubeStateURL {
-				t.Errorf("GetServiceURLs() kubeStateMetricsURL = %v, expected %v", kubeStateMetricsURL, tt.expectedKubeStateURL)
-			}
-			if nodeExporterURL != tt.expectedNodeExporterURL {
-				t.Errorf("GetServiceURLs() nodeExporterURL = %v, expected %v", nodeExporterURL, tt.expectedNodeExporterURL)
-			}
-		})
-	}
+	_, err = clientset.CoreV1().Services(namespace).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-exporter",
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port: 9100,
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	kubeStateMetricsURL, nodeExporterURL, err := k8s.GetServiceURLs(ctx, clientset, namespace)
+	assert.NoError(t, err)
+	assert.Contains(t, kubeStateMetricsURL, "kube-state-metrics")
+	assert.Contains(t, nodeExporterURL, "node-exporter")
 }
 
-// TestUpdateConfigMap tests the UpdateConfigMap function
 func TestUpdateConfigMap(t *testing.T) {
-	tests := []struct {
-		name             string
-		initialConfigMap *corev1.ConfigMap
-		updatedData      map[string]string
-		expectError      bool
-	}{
-		{
-			name: "Update ConfigMap successfully",
-			initialConfigMap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-configmap",
-					Namespace: "default",
-				},
-				Data: map[string]string{
-					"key1": "value1",
-				},
-			},
-			updatedData: map[string]string{
-				"key1": "new-value1",
-				"key2": "value2",
-			},
-			expectError: false,
+	clientset := fake.NewSimpleClientset()
+	ctx := context.TODO()
+	namespace := "test-namespace"
+
+	// Create a ConfigMap
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: namespace,
 		},
-		{
-			name:             "Create ConfigMap successfully",
-			initialConfigMap: nil,
-			updatedData: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-			},
-			expectError: false,
+		Data: map[string]string{
+			"key1": "value1",
 		},
 	}
+	_, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	assert.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset()
-			if tt.initialConfigMap != nil {
-				clientset = fake.NewSimpleClientset(tt.initialConfigMap)
-			}
-
-			err := k8s.UpdateConfigMap(context.Background(), clientset, "default", "test-configmap", tt.updatedData)
-			if (err != nil) != tt.expectError {
-				t.Errorf("UpdateConfigMap() error = %v, expectError %v", err, tt.expectError)
-				return
-			}
-
-			// Verify the ConfigMap was updated or created
-			updatedConfigMap, err := clientset.CoreV1().ConfigMaps("default").Get(context.Background(), "test-configmap", metav1.GetOptions{})
-			if err != nil {
-				t.Errorf("GetConfigMap() error = %v", err)
-				return
-			}
-
-			for key, expectedValue := range tt.updatedData {
-				if updatedConfigMap.Data[key] != expectedValue {
-					t.Errorf("ConfigMap data mismatch for key %s: got %v, expected %v", key, updatedConfigMap.Data[key], expectedValue)
-				}
-			}
-		})
+	// Update the ConfigMap
+	newData := map[string]string{
+		"key1": "new-value1",
+		"key2": "value2",
 	}
+	err = k8s.UpdateConfigMap(ctx, clientset, namespace, "test-configmap", newData)
+	assert.NoError(t, err)
+
+	// Verify the ConfigMap was updated
+	updatedConfigMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, "test-configmap", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, newData, updatedConfigMap.Data)
+}
+
+func TestBuildKubeClient(t *testing.T) {
+	// Create a temporary kubeconfig file
+	kubeconfigContent := `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+preferences: {}
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
+	assert.NoError(t, err)
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	_, err = tmpfile.Write([]byte(kubeconfigContent))
+	assert.NoError(t, err)
+	err = tmpfile.Close()
+	assert.NoError(t, err)
+
+	// Build the kube client using the temporary kubeconfig file
+	clientset, err := k8s.BuildKubeClient(tmpfile.Name())
+	assert.NoError(t, err)
+	assert.NotNil(t, clientset)
 }


### PR DESCRIPTION
This was a small miss #33, essentially we need to use the argument `namespace`, rather than `"default"`. 