### PR TITLE
CP-21862: Generate Command should Allow users to specify CloudZero Secret File Path

### DIFF
--- a/pkg/cmd/config/command.go
+++ b/pkg/cmd/config/command.go
@@ -29,6 +29,7 @@ type ScrapeConfigData struct {
 	CloudAccountID string
 	Region         string
 	Host           string
+	SecretPath     string
 }
 
 func NewCommand(ctx context.Context) *cli.Command {
@@ -48,12 +49,14 @@ func NewCommand(ctx context.Context) *cli.Command {
 					&cli.StringFlag{Name: "configmap", Usage: "name of the ConfigMap", Required: true},
 					&cli.StringFlag{Name: "pod", Usage: "name of the cloudzero-agent pod", Required: true},
 					&cli.StringFlag{Name: "host", Usage: "host for the prometheus remote write endpoint", Required: true},
+					&cli.StringFlag{Name: "secret-path", Usage: "path to the secret file", Value: "/etc/config/prometheus/secrets/", Required: false},
 				},
 				Action: func(c *cli.Context) error {
 					kubeconfigPath := c.String("kubeconfig")
 					namespace := c.String("namespace")
 					configMapName := c.String("configmap")
 					host := c.String("host")
+					secretPath := c.String("secret-path")
 
 					clientset, err := k8s.BuildKubeClient(kubeconfigPath)
 					if err != nil {
@@ -72,6 +75,7 @@ func NewCommand(ctx context.Context) *cli.Command {
 						CloudAccountID: c.String(config.FlagAccountID),
 						Region:         c.String(config.FlagRegion),
 						Host:           host,
+						SecretPath:     secretPath,
 					}
 
 					configContent, err := Generate(scrapeConfigData)

--- a/pkg/cmd/config/command_test.go
+++ b/pkg/cmd/config/command_test.go
@@ -46,6 +46,7 @@ func TestGenerate(t *testing.T) {
 		CloudAccountID: "123456789",
 		Region:         "us-west-2",
 		Host:           "test-host",
+		SecretPath:     "/etc/config/prometheus/secrets/",
 	}
 
 	// Generate the configuration content
@@ -59,6 +60,7 @@ func TestGenerate(t *testing.T) {
 	assert.Contains(t, configContent, "cloud_account_id=123456789")
 	assert.Contains(t, configContent, "region=us-west-2")
 	assert.Contains(t, configContent, "test-host")
+	assert.Contains(t, configContent, "/etc/config/prometheus/secrets/")
 
 	// Define the ConfigMap data
 	configMapData := map[string]string{


### PR DESCRIPTION
This PR modifies the `generate` command by allowing users to include the path to their secret. 

The value originates from: https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/templates/cm.yaml#L162
