### PR TITLE
CP-22291: remove latest tag in build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -76,7 +76,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
           labels: |
             maintainer=CloudZero
             org.opencontainers.image.description=${{ env.VALIDATOR_IMAGE_DESCRIPTION }}
@@ -85,7 +84,7 @@ jobs:
           # https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag
           # should only occur whtn a semver or raw when we are on master
           flavor: |
-            latest=auto
+            latest=false
 
       - name: INPUT PREP - Set build time revision
         run: |


### PR DESCRIPTION
I changed `latest=auto` to `latest=false` based on the docs [here](https://github.com/docker/metadata-action/tree/8e5442c4ef9f78752691e2d8f8d19755c6f78e81/?tab=readme-ov-file#flavor-input), with the thinking that we don't want this to be handled by this build step

testing on my fork in progress