### PR TITLE
CP-22509: Search All Namespaces for KSM and Improve Search Logic

### DIFF
--- a/pkg/cmd/config/command.go
+++ b/pkg/cmd/config/command.go
@@ -63,7 +63,7 @@ func NewCommand(ctx context.Context) *cli.Command {
 						return err
 					}
 
-					kubeStateMetricsURL, err := k8s.GetKubeStateMetricsURL(ctx, clientset, namespace)
+					kubeStateMetricsURL, err := k8s.GetKubeStateMetricsURL(ctx, clientset)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/config/command_test.go
+++ b/pkg/cmd/config/command_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/k8s"
 )
 
-func TestGenerate(t *testing.T) {
+func TestGenerateByName(t *testing.T) {
 	// Define the namespace to be used in the test
 	namespace := "test-namespace"
 
-	// Create a fake clientset with some services
+	// Create a fake clientset with a service named "kube-state-metrics"
 	clientset := fake.NewSimpleClientset(
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -36,7 +36,81 @@ func TestGenerate(t *testing.T) {
 	ctx, _ := context.WithCancel(context.Background())
 
 	// Fetch the Kube State Metrics URL
-	kubeStateMetricsURL, err := k8s.GetKubeStateMetricsURL(ctx, clientset, namespace)
+	kubeStateMetricsURL, err := k8s.GetKubeStateMetricsURL(ctx, clientset)
+	assert.NoError(t, err)
+
+	// Define the scrape config data
+	scrapeConfigData := config.ScrapeConfigData{
+		Targets:        []string{kubeStateMetricsURL},
+		ClusterName:    "test-cluster",
+		CloudAccountID: "123456789",
+		Region:         "us-west-2",
+		Host:           "test-host",
+		SecretPath:     "/etc/config/prometheus/secrets/",
+	}
+
+	// Generate the configuration content
+	configContent, err := config.Generate(scrapeConfigData)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, configContent)
+
+	// Validate the dynamically populated values
+	assert.Contains(t, configContent, kubeStateMetricsURL)
+	assert.Contains(t, configContent, "cluster_name=test-cluster")
+	assert.Contains(t, configContent, "cloud_account_id=123456789")
+	assert.Contains(t, configContent, "region=us-west-2")
+	assert.Contains(t, configContent, "test-host")
+	assert.Contains(t, configContent, "/etc/config/prometheus/secrets/")
+
+	// Define the ConfigMap data
+	configMapData := map[string]string{
+		"prometheus.yml": configContent,
+	}
+
+	// Update the ConfigMap
+	err = k8s.UpdateConfigMap(ctx, clientset, namespace, "test-configmap", configMapData)
+	assert.NoError(t, err)
+
+	// Verify the ConfigMap was updated
+	updatedConfigMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, "test-configmap", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, configContent, updatedConfigMap.Data["prometheus.yml"])
+
+	// Clean up the output file if it exists
+	outputFile := "test_output.yml"
+	if _, err := os.Stat(outputFile); err == nil {
+		err = os.Remove(outputFile)
+		assert.NoError(t, err)
+	}
+}
+
+func TestGenerateByLabel(t *testing.T) {
+	// Define the namespace to be used in the test
+	namespace := "test-namespace"
+
+	// Create a fake clientset with a service having Helm-specific labels
+	clientset := fake.NewSimpleClientset(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-service-name",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "kube-state-metrics",
+					"helm.sh/chart":          "kube-state-metrics-2.11.1",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{Port: 8080},
+				},
+			},
+		},
+	)
+
+	ctx, _ := context.WithCancel(context.Background())
+
+	// Fetch the Kube State Metrics URL
+	kubeStateMetricsURL, err := k8s.GetKubeStateMetricsURL(ctx, clientset)
 	assert.NoError(t, err)
 
 	// Define the scrape config data

--- a/pkg/k8s/services.go
+++ b/pkg/k8s/services.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
This PR modifies the `generate` command to search for KSM in _all_ namespaces. Additionally, if KSM is not found by searching for the substring in the Service name iteself, the command checks the Service's Labels for `"app.kubernetes.io/name": "kube-state-metrics`, which should be more robust.