### PR TITLE
CP-23050: Validate CloudZero Metrics are available from Kube State Metrics

### DIFF
--- a/pkg/diagnostic/catalog/catalog_test.go
+++ b/pkg/diagnostic/catalog/catalog_test.go
@@ -2,14 +2,34 @@ package catalog_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/catalog"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/kms"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
 )
 
+type mockProvider struct{}
+
+func (m *mockProvider) Check(ctx context.Context, client *http.Client, recorder status.Accessor) error {
+	return nil
+}
+
+func mockKMSProvider(ctx context.Context, cfg *config.Settings, clientset ...kubernetes.Interface) diagnostic.Provider {
+	return &mockProvider{}
+}
+
 func TestRegistry_Get(t *testing.T) {
+	// Override kms.NewProvider
+	originalNewProvider := kms.NewProvider
+	kms.NewProvider = mockKMSProvider
+	defer func() { kms.NewProvider = originalNewProvider }()
+
 	ctx := context.Background()
 	c := &config.Settings{}
 	r := catalog.NewCatalog(ctx, c)
@@ -28,6 +48,11 @@ func TestRegistry_Get(t *testing.T) {
 }
 
 func TestRegistry_Has(t *testing.T) {
+	// Override kms.NewProvider
+	originalNewProvider := kms.NewProvider
+	kms.NewProvider = mockKMSProvider
+	defer func() { kms.NewProvider = originalNewProvider }()
+
 	ctx := context.Background()
 	c := &config.Settings{}
 	r := catalog.NewCatalog(ctx, c)
@@ -42,6 +67,11 @@ func TestRegistry_Has(t *testing.T) {
 }
 
 func TestRegistry_List(t *testing.T) {
+	// Override kms.NewProvider
+	originalNewProvider := kms.NewProvider
+	kms.NewProvider = mockKMSProvider
+	defer func() { kms.NewProvider = originalNewProvider }()
+
 	ctx := context.Background()
 	c := &config.Settings{}
 	r := catalog.NewCatalog(ctx, c)

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -62,7 +62,7 @@ var NewProvider = func(ctx context.Context, cfg *config.Settings, clientset ...k
 	}
 }
 
-func (c *checker) Check(ctx context.Context, client *http.Client, accessor status.Accessor) error {
+func (c *checker) Check(_ context.Context, client *http.Client, accessor status.Accessor) error {
 	var (
 		retriesRemaining = MaxRetry
 		endpointURL      = fmt.Sprintf("%s/metrics", c.cfg.Prometheus.KubeStateMetricsServiceEndpoint)

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -3,15 +3,20 @@ package kms
 import (
 	"context"
 	"fmt"
-	net "net/http"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/http"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const DiagnosticKMS = config.DiagnosticKMS
@@ -23,46 +28,130 @@ var (
 )
 
 type checker struct {
-	cfg    *config.Settings
-	logger *logrus.Entry
+	cfg       *config.Settings
+	logger    *logrus.Entry
+	clientset kubernetes.Interface
 }
 
-func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider {
+func NewProvider(ctx context.Context, cfg *config.Settings, clientset ...kubernetes.Interface) diagnostic.Provider {
+	var cs kubernetes.Interface
+	if len(clientset) > 0 {
+		cs = clientset[0]
+	} else {
+		// Use the in-cluster config if running inside a cluster, otherwise use the default kubeconfig
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			kubeconfig := clientcmd.RecommendedHomeFile
+			config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+			if err != nil {
+				panic(err.Error())
+			}
+		}
+
+		// Create the clientset
+		cs, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+
 	return &checker{
 		cfg: cfg,
 		logger: logging.NewLogger().
 			WithContext(ctx).WithField(logging.OpField, "ksm"),
+		clientset: cs,
 	}
 }
 
-func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor) error {
+func (c *checker) Check(ctx context.Context, client *http.Client, accessor status.Accessor) error {
 	var (
-		err              error
 		retriesRemaining = MaxRetry
-		url              = fmt.Sprintf("%s/", c.cfg.Prometheus.KubeStateMetricsServiceEndpoint)
+		namespace        = "prom-agent"
+		serviceName      = "cz-prom-agent-kube-state-metrics"
+		endpointURL      string
 	)
 
-	// We need to build in a retry here because the kube-state-metrics service can take a few seconds to start up
-	// If it is deploying with the cloudzero-agent chart
-	for {
-		_, err = http.Do(ctx, client, net.MethodGet, nil, nil, url, nil)
-		if err == nil {
-			break
+	// Wait for the pod to become ready and find the first available endpoint
+	for retriesRemaining > 0 {
+		endpoints, err := c.clientset.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			c.logger.Errorf("Failed to get service endpoints: %v", err)
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to get service endpoints: %s", err.Error())})
+			return nil
 		}
-		if retriesRemaining == 0 {
+
+		// Log the endpoints for debugging
+		c.logger.Infof("Endpoints: %v", endpoints)
+
+		// Check if there are any ready addresses and find the first available endpoint
+		for _, subset := range endpoints.Subsets {
+			for _, address := range subset.Addresses {
+				c.logger.Infof("Address: %v", address)
+				for _, port := range subset.Ports {
+					c.logger.Infof("Port: %v", port)
+					if port.Port == 8080 {
+						endpointURL = fmt.Sprintf("http://%s:%d/metrics", address.IP, port.Port)
+						break
+					}
+				}
+				if endpointURL != "" {
+					break
+				}
+			}
+			if endpointURL != "" {
+				break
+			}
+		}
+
+		if endpointURL != "" {
 			break
 		}
 
+		c.logger.Infof("Pod is not ready, waiting...")
 		retriesRemaining--
 		time.Sleep(RetryInterval)
 	}
 
-	if err != nil {
-		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: err.Error()})
+	if retriesRemaining == 0 {
+		c.logger.Errorf("Pod did not become ready in time")
+		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: "Pod did not become ready in time"})
 		return nil
 	}
 
-	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
-	return nil
+	c.logger.Infof("Using endpoint URL: %s", endpointURL)
 
+	// Retry logic to handle transient issues
+	retriesRemaining = MaxRetry
+	for retriesRemaining > 0 {
+		resp, err := client.Get(endpointURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				c.logger.Errorf("Failed to read metrics: %v", err)
+				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to read metrics: %s", err.Error())})
+				return nil
+			}
+
+			metrics := string(body)
+			requiredMetrics := []string{"kube_pod_info", "kube_node_info"} // Add the required metrics here
+			for _, metric := range requiredMetrics {
+				if !strings.Contains(metrics, metric) {
+					c.logger.Errorf("Required metric %s not found", metric)
+					accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
+					return nil
+				}
+			}
+
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
+			return nil
+		}
+
+		c.logger.Errorf("Failed to fetch metrics: %v", err)
+		retriesRemaining--
+		time.Sleep(RetryInterval)
+	}
+
+	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to fetch metrics after %d retries", MaxRetry)})
+	return nil
 }

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -33,7 +33,7 @@ type checker struct {
 	clientset kubernetes.Interface
 }
 
-func NewProvider(ctx context.Context, cfg *config.Settings, clientset ...kubernetes.Interface) diagnostic.Provider {
+var NewProvider = func(ctx context.Context, cfg *config.Settings, clientset ...kubernetes.Interface) diagnostic.Provider {
 	var cs kubernetes.Interface
 	if len(clientset) > 0 {
 		cs = clientset[0]

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -3,7 +3,7 @@ package kms
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -126,7 +126,7 @@ func (c *checker) Check(ctx context.Context, client *http.Client, accessor statu
 		resp, err := client.Get(endpointURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				c.logger.Errorf("Failed to read metrics: %v", err)
 				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to read metrics: %s", err.Error())})

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -7,6 +7,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/kms"
@@ -22,16 +27,40 @@ func makeReport() status.Accessor {
 	return status.NewAccessor(&status.ClusterStatus{})
 }
 
+// createMockEndpoints creates mock endpoints and adds them to the fake clientset
+func createMockEndpoints(clientset *fake.Clientset) {
+	clientset.PrependReactor("get", "endpoints", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cz-prom-agent-kube-state-metrics",
+				Namespace: "prom-agent",
+			},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{IP: "192.168.1.1"},
+					},
+					Ports: []corev1.EndpointPort{
+						{Name: "http", Port: 8080},
+					},
+				},
+			},
+		}, nil
+	})
+}
+
 func TestChecker_CheckOK(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	mock := test.NewHTTPMock()
-	mock.Expect(http.MethodGet, "Hello World", http.StatusOK, nil)
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
@@ -53,15 +82,19 @@ func TestChecker_CheckRetry(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
-	// Update the test sleep interval to accellerate the test
+	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
+	kms.MaxRetry = 3
+
 	mock := test.NewHTTPMock()
-	for i := 0; i < kms.MaxRetry; i++ {
+	for i := 0; i < kms.MaxRetry-1; i++ {
 		mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
 	}
-	mock.Expect(http.MethodGet, "Hello World", http.StatusOK, nil)
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
@@ -83,14 +116,72 @@ func TestChecker_CheckRetryFailure(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
-	// Update the test sleep interval to accellerate the test
+	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
-	kms.MaxRetry = 0
+	kms.MaxRetry = 3
 
 	mock := test.NewHTTPMock()
-	mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
+	for i := 0; i < kms.MaxRetry; i++ {
+		mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
+	}
+	client := mock.HTTPClient()
+
+	accessor := makeReport()
+
+	err := provider.Check(context.Background(), client, accessor)
+	assert.NoError(t, err)
+
+	accessor.ReadFromReport(func(s *status.ClusterStatus) {
+		assert.Len(t, s.Checks, 1)
+		for _, c := range s.Checks {
+			assert.False(t, c.Passing)
+		}
+	})
+}
+
+func TestChecker_CheckMetricsValidation(t *testing.T) {
+	cfg := &config.Settings{
+		Prometheus: config.Prometheus{
+			KubeStateMetricsServiceEndpoint: mockURL,
+		},
+	}
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
+
+	mock := test.NewHTTPMock()
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
+	client := mock.HTTPClient()
+
+	accessor := makeReport()
+
+	err := provider.Check(context.Background(), client, accessor)
+	assert.NoError(t, err)
+
+	accessor.ReadFromReport(func(s *status.ClusterStatus) {
+		assert.Len(t, s.Checks, 1)
+		for _, c := range s.Checks {
+			assert.True(t, c.Passing)
+		}
+	})
+}
+
+func TestChecker_CheckHandles500Error(t *testing.T) {
+	cfg := &config.Settings{
+		Prometheus: config.Prometheus{
+			KubeStateMetricsServiceEndpoint: mockURL,
+		},
+	}
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
+
+	mock := test.NewHTTPMock()
+	mock.Expect(http.MethodGet, "", http.StatusInternalServerError, nil)
 	client := mock.HTTPClient()
 
 	accessor := makeReport()


### PR DESCRIPTION
This PR modifies the `kube_state_metrics_reachable` `post-start` job to also validate that all CloudZero KMS metrics are available. A sample log output from the Job:
``` json
{
  "level": "info",
  "log_sequence": 6,
  "msg": "Using endpoint URL: http://192.168.5.249:8080/metrics",     <---- Internal IP discovered using the Service Endpoint 
  "op": "ksm",
  "time": "2024-11-25T08:23:44Z"
}
{
  "level": "info",
  "log_sequence": 7,
  "msg": "All required metrics found: [kube_pod_info kube_node_info]",                <---- Metric Check (subset for now)
  "op": "ksm",
 }
 
```

``` bash
Part of the Cluster Status Report related to KMS produced by the Job: {\"name\":\"kube_state_metrics_reachable\",\"passing\":true}]}",
```

The log statements show that the job was able to discover the internal IP of the KSM service, find all required metrics, and mark the `kube_state_metrics_reachable` job as complete.


It's worth noting that the base branch is `feature/cp-23050`, not `develop`. The remaining work will be handled in a subsequent ticket. I hard coded some values temporarily to prove out the functionality until we can get around to the Chart changes in https://cloudzero.atlassian.net/browse/CP-23740.