### PR TITLE
CP-23740: Use Required KSM Metrics From Chart when Validating KSM

### DIFF
--- a/pkg/config/prometheus.go
+++ b/pkg/config/prometheus.go
@@ -11,6 +11,7 @@ type Prometheus struct {
 	Executable                      string   `yaml:"executable" default:"/bin/prometheus" env:"PROMETHEUS_EXECUTABLE" env-description:"Prometheus Executable Path"`
 	KubeStateMetricsServiceEndpoint string   `yaml:"kube_state_metrics_service_endpoint" env:"KMS_EP_URL" required:"true" env-description:"Kube State Metrics Service Endpoint"`
 	Configurations                  []string `yaml:"configurations"`
+	KubeMetrics                     []string `yaml:"kube_metrics"`
 }
 
 func (s *Prometheus) Validate() error {
@@ -43,5 +44,10 @@ func (s *Prometheus) Validate() error {
 		}
 		s.Configurations = cleanedPaths
 	}
+
+	if len(s.KubeMetrics) == 0 {
+		return errors.New("no KubeMetrics provided")
+	}
+
 	return nil
 }

--- a/pkg/config/prometheus_test.go
+++ b/pkg/config/prometheus_test.go
@@ -23,6 +23,7 @@ func TestPrometheus_Validate(t *testing.T) {
 			prom: config.Prometheus{
 				KubeStateMetricsServiceEndpoint: kmsServiceEndpoint,
 				Configurations:                  []string{scrapeConfigFile},
+				KubeMetrics:                     []string{"kube_node_info", "kube_pod_info"},
 			},
 			expected: nil,
 		},
@@ -30,6 +31,7 @@ func TestPrometheus_Validate(t *testing.T) {
 			name: "MissingKubeStateMetricsServiceEndpoint",
 			prom: config.Prometheus{
 				Configurations: []string{scrapeConfigFile},
+				KubeMetrics:    []string{"kube_node_info", "kube_pod_info"},
 			},
 			expected: errors.New(config.ErrNoKubeStateMetricsServiceEndpointMsg),
 		},
@@ -37,8 +39,17 @@ func TestPrometheus_Validate(t *testing.T) {
 			name: "MissingScrapeConfigLocation",
 			prom: config.Prometheus{
 				KubeStateMetricsServiceEndpoint: kmsServiceEndpoint,
+				KubeMetrics:                     []string{"kube_node_info", "kube_pod_info"},
 			},
 			expected: nil,
+		},
+		{
+			name: "MissingKubeMetrics",
+			prom: config.Prometheus{
+				KubeStateMetricsServiceEndpoint: kmsServiceEndpoint,
+				Configurations:                  []string{scrapeConfigFile},
+			},
+			expected: errors.New("no KubeMetrics provided"),
 		},
 	}
 

--- a/pkg/config/testdata/cloudzero-agent-validator.yml
+++ b/pkg/config/testdata/cloudzero-agent-validator.yml
@@ -18,6 +18,14 @@ cloudzero:
 
 prometheus:
   kube_state_metrics_service_endpoint: http://kube-state-metrics:8080
+  kube_metrics:
+    - kube_node_info
+    - kube_node_status_capacity
+    - kube_pod_container_resource_limits
+    - kube_pod_container_resource_requests
+    - kube_pod_labels
+    - kube_pod_info
+    - node_dmi_info
   configurations: 
     - prometheus.yml
 

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -96,7 +96,7 @@ func (c *checker) Check(_ context.Context, client *http.Client, accessor status.
 		}
 
 		metrics := string(body)
-		requiredMetrics := []string{"kube_pod_info", "kube_node_info"} // Add the required metrics here
+		requiredMetrics := c.cfg.Prometheus.KubeMetrics // Use the required metrics from the configuration
 		for _, metric := range requiredMetrics {
 			if !strings.Contains(metrics, metric) {
 				c.logger.Errorf("Required metric %s not found on attempt %d", metric, attempt)

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -96,17 +96,22 @@ func (c *checker) Check(_ context.Context, client *http.Client, accessor status.
 		}
 
 		metrics := string(body)
-		requiredMetrics := c.cfg.Prometheus.KubeMetrics // Use the required metrics from the configuration
-		for _, metric := range requiredMetrics {
+		allMetricsFound := true
+		for _, metric := range c.cfg.Prometheus.KubeMetrics {
 			if !strings.Contains(metrics, metric) {
 				c.logger.Errorf("Required metric %s not found on attempt %d", metric, attempt)
 				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
-				return nil
+				allMetricsFound = false
 			}
 		}
 
-		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
-		return nil
+		if allMetricsFound {
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
+			return nil
+		}
+
+		retriesRemaining--
+		time.Sleep(RetryInterval)
 	}
 
 	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to fetch metrics after %d retries", MaxRetry)})

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -53,6 +53,7 @@ func TestChecker_CheckOK(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
+			KubeMetrics:                     []string{"kube_pod_info", "kube_node_info"},
 		},
 	}
 	clientset := fake.NewSimpleClientset()
@@ -80,6 +81,7 @@ func TestChecker_CheckRetry(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
+			KubeMetrics:                     []string{"kube_pod_info", "kube_node_info"},
 		},
 	}
 	clientset := fake.NewSimpleClientset()
@@ -114,6 +116,7 @@ func TestChecker_CheckRetryFailure(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
+			KubeMetrics:                     []string{"kube_pod_info", "kube_node_info"},
 		},
 	}
 	clientset := fake.NewSimpleClientset()
@@ -147,6 +150,7 @@ func TestChecker_CheckMetricsValidation(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
+			KubeMetrics:                     []string{"kube_pod_info", "kube_node_info"},
 		},
 	}
 	clientset := fake.NewSimpleClientset()
@@ -174,6 +178,7 @@ func TestChecker_CheckHandles500Error(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
+			KubeMetrics:                     []string{"kube_pod_info", "kube_node_info"},
 		},
 	}
 	clientset := fake.NewSimpleClientset()


### PR DESCRIPTION
**Description**

This PR modifies the `kube_state_metrics_reachable` command by including the full list of KSM metrics passed by the chart, rather than the hardcoded subset used during testing.

Accompanying Chart changes: https://github.com/Cloudzero/cloudzero-charts/pull/115


**Testing**
Below is the output of the CloudZero Agent Server `post-start` job. If you notice, the logs outline the metrics being validated, eventually leading to a passing status for `kube_state_metrics_reachable`:
``` json
{
  "level": "info",
  "log_sequence": 1,
  "msg": "Using endpoint URL: http://cloudzero-state-metrics.prom-agent.svc.cluster.local:8080/metrics",
  "op": "ksm",
  "time": "2024-12-03T21:52:29Z"
}
{
  "level": "error",
  "log_sequence": 2,
  "msg": "Failed to fetch metrics on attempt 1: Get \"http://cloudzero-state-metrics.prom-agent.svc.cluster.local:8080/metrics\": dial tcp 10.100.123.115:8080: connect: connection refused",
  "op": "ksm",
  "time": "2024-12-03T21:52:29Z"
}
{
  "level": "info",
  "log_sequence": 3,
  "msg": "Found required metric kube_node_info on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 4,
  "msg": "Found required metric kube_node_status_capacity on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 5,
  "msg": "Found required metric kube_pod_container_resource_limits on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 6,
  "msg": "Found required metric kube_pod_container_resource_requests on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 7,
  "msg": "Found required metric kube_pod_labels on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 8,
  "msg": "Found required metric kube_pod_info on attempt 2",
  "op": "ksm",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 9,
  "msg": "reporting status",
  "report": "{
    ...
  {\"name\":\"prometheus_version\",\"passing\":true},{\"name\":\"kube_state_metrics_reachable\",\"passing\":true}]}",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 10,
  "msg": "marshalled cluster status: 5683 bytes",
  "time": "2024-12-03T21:52:39Z"
}
{
  "level": "info",
  "log_sequence": 11,
  "msg": "compressed size is: 5683 bytes",
  "time": "2024-12-03T21:52:39Z"
}


```