### PR TITLE
Minor dev documentation update

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,6 +48,7 @@ To quickly get started with the development of the CloudZero Agent Validator, fo
 
    ```sh
    $ go mod download
+   $  make install-tools
    ```
 
 2. Generate the status protobuf definition package:
@@ -67,7 +68,7 @@ To quickly get started with the development of the CloudZero Agent Validator, fo
 To run the go formatter, go linter, unit tests to verify code changes, use the following command:
 
 ```sh
-make fmt lint test
+make format lint test
 ```
 
 ### 4. CI/CD Testing
@@ -141,6 +142,6 @@ Finally - we will publish the `draft-release`. Make sure you:
 
 ![](./docs/assets/release-3.png)
 
-When this is done, it will cause an automated release of teh `docker image` for the release value, and `latest` to be created in GHCR.
+When this is done, it will cause an automated release of the `docker image` for the release value, and `latest` to be created in GHCR.
 
 That's it, Happy coding!


### PR DESCRIPTION
@evan-cz @roberthocking This is a small update to the development documentation for the repo after I ran through building it.

It turns out that the `develop` branch isn't protected, as I accidentally pushed this straight to `develop` when I though I was on a small branch, but I reverted that, and it is in this PR now.