### PR TITLE
Chart: Add dnsPolicy and dnsConfig configurables to deployment/job specs

### DIFF
--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -101,7 +101,10 @@ spec:
         runAsNonRoot: true
         runAsGroup: 65534
         fsGroup: 65534
-      dnsPolicy: ClusterFirst
+      dnsPolicy: {{ .Values.aggregator.dnsPolicy }}
+      {{- if .Values.aggregator.dnsConfig }}
+      dnsConfig: {{ .Values.aggregator.dnsConfig | nindent 8 }}
+      {{- end }}
       {{- include "cloudzero-agent.server.imagePullSecrets" . | nindent 6 -}}
 
       {{- with .Values.aggregator.nodeSelector }}

--- a/helm/templates/deploy.yaml
+++ b/helm/templates/deploy.yaml
@@ -135,13 +135,15 @@ spec:
             - name: validator-config-volume
               mountPath: /check/app/config/
             {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
-
       securityContext:
         runAsUser: 65534
         runAsNonRoot: true
         runAsGroup: 65534
         fsGroup: 65534
-      dnsPolicy: ClusterFirst
+      dnsPolicy: {{ .Values.server.dnsPolicy }}
+      {{- if .Values.server.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.server.dnsConfig | nindent 8 }}
+      {{- end }}
       {{- include "cloudzero-agent.server.imagePullSecrets" . | nindent 6 -}}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -20,6 +20,10 @@ spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       restartPolicy: OnFailure
       {{- include  "cloudzero-agent.initBackfillJob.imagePullSecrets" . | nindent 6 }}
+      dnsPolicy: {{ .Values.insightsController.server.dnsPolicy }}
+      {{- if .Values.insightsController.server.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.insightsController.server.dnsConfig | nindent 8 }}
+      {{- end }}
       containers:
         - name: init-scrape
           image: "{{ include  "cloudzero-agent.initBackfillJob.imageReference" . }}"
@@ -110,6 +114,10 @@ spec:
       serviceAccountName: {{ include "cloudzero-agent.initCertJob.serviceAccountName" . }}
       restartPolicy: Never
       {{- include  "cloudzero-agent.initCertJob.imagePullSecrets" . | nindent 6 }}
+      dnsPolicy: {{ .Values.initCertJob.dnsPolicy }}
+      {{- if .Values.initCertJob.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.initCertJob.dnsConfig | nindent 8 }}
+      {{- end }}
       containers:
         - name: init-cert
           image: {{ .Values.initCertJob.image.repository }}:{{ .Values.initCertJob.image.tag }}

--- a/helm/templates/insights-deploy.yaml
+++ b/helm/templates/insights-deploy.yaml
@@ -43,6 +43,10 @@ spec:
                   matchLabels:
                     app: webhook-server
                 topologyKey: "kubernetes.io/hostname"
+      dnsPolicy: {{ .Values.insightsController.server.dnsPolicy }}
+      {{- if .Values.insightsController.server.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.insightsController.server.dnsConfig | nindent 8 }}
+      {{- end }}
       containers:
         - name: webhook-server
           image: "{{ .Values.insightsController.server.image.repository }}:{{ .Values.insightsController.server.image.tag | default .Chart.AppVersion }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -391,6 +391,8 @@ initCertJob:
     repository: bitnami/kubectl
     pullPolicy: Always
     tag: "1.32.0"
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
   rbac:
     create: true
     serviceAccountName: ""
@@ -455,6 +457,8 @@ server:
       memory: 1024Mi
   deploymentAnnotations: {}
   podAnnotations: {}
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
   agentMode: true
   args:
     - --config.file=/etc/config/prometheus/configmaps/prometheus.yml
@@ -553,6 +557,8 @@ insightsController:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    dnsPolicy: ClusterFirst
+    dnsConfig: {}
   volumeMounts: []
   volumes: []
   resources: {}
@@ -645,6 +651,8 @@ aggregator:
     repository: ghcr.io/cloudzero/cloudzero-insights-controller/cloudzero-insights-controller
     tag: 0.2.1
     pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
   cloudzero:
     # Interval between attempts to ship metrics to the remote endpoint.
     sendInterval: 1m


### PR DESCRIPTION
Users might have some interesting DNS requirements (e.g. Wise). This allows them to override the `dnsConfig` and `dnsPolicy` without directly modifying the chart. 

Defaults are defined [as per Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy).
