### PR TITLE
CP-27614: document using agent-validator repo for Helm chart changes

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -268,6 +268,10 @@ kubeStateMetrics:
     repository: my-custom-kube-state-metrics/kube-state-metrics
 ```
 
+## Contributing
+
+We welcome contributions to the CloudZero Agent Helm chart. Contributions for this chart are managed through the [CloudZero Agent Validator repository](https://github.com/cloudzero/cloudzero-agent-validator), which is then automatically synced to the [CloudZero Charts repository](https://github.com/cloudzero/cloudzero-charts). We cannot accept contributions for anything in this directory through the CloudZero Charts repository as they would be overwritten automatically the next time a change is made in the CloudZero Agent Validator repository.
+
 ## Dependencies
 
 | Repository                                         | Name               | Version |


### PR DESCRIPTION
Not that I expect people to reliably read this, but hopefully in conjunction with the GitHub Action which will error if people try to make a chnage to the charts/cloudzero-agent directory in the cloudzero-charts repo people will be able to find the right location for contributions.